### PR TITLE
Add support for predicting opponent orders

### DIFF
--- a/fairdiplomacy/utils/base_strategy_model_multi_gpu_wrappers.py
+++ b/fairdiplomacy/utils/base_strategy_model_multi_gpu_wrappers.py
@@ -37,7 +37,7 @@ class MultiProcessBaseStrategyModelExecutor:
         if allow_multi_gpu and torch.cuda.device_count() > 2:
             # Will not use GPU:0, >2 so that we don't run on devfair.
             self._num_workers = torch.cuda.device_count() - 1
-            logging.info("Buillding MultiProcessParlaiExecutor for %d devices", self._num_workers)
+            logging.info("Building MultiProcessParlaiExecutor for %d devices", self._num_workers)
             self._executor = concurrent.futures.ProcessPoolExecutor(
                 max_workers=self._num_workers, mp_context=mp,
             )

--- a/fairdiplomacy/utils/parlai_multi_gpu_wrappers.py
+++ b/fairdiplomacy/utils/parlai_multi_gpu_wrappers.py
@@ -75,7 +75,7 @@ def wrap_parlai_model_to_executor(parlai_model: BaseWrapper,) -> ParlaiExecutor:
 
 class PseudoParlaiExecutor(ParlaiExecutor):
     def __init__(self, parlai_model: BaseWrapper):
-        logging.info("Buillding PseudoParlaiExecutor (no parallelizm)")
+        logging.info("Building PseudoParlaiExecutor (no parallelism)")
         self._model = parlai_model
 
     def is_loaded(self) -> bool:

--- a/fairdiplomacy_external/mila_api_advisor.py
+++ b/fairdiplomacy_external/mila_api_advisor.py
@@ -67,7 +67,7 @@ class CiceroAdvisor(CiceroBot):
     """Advisor form of `CiceroBot`."""
 
     bot_type = BotType.ADVISOR
-    suggestion_type = SuggestionType.MESSAGE | SuggestionType.MOVE
+    suggestion_type = None
 
 
 class milaWrapper:
@@ -221,6 +221,9 @@ class milaWrapper:
             if not is_reload_advisor or power_name is None:
                 power_name = self.get_curr_power_to_advise()
                 self.chiron_type = self.get_curr_advice_level()
+                # Only one instance of `ChironAdvisor` exists at a time,
+                # so this is actually safe
+                self.chiron_agent.suggestion_type = self.chiron_type
                 self.chiron_agent.power_name = power_name
                 self.dipcc_game = self.start_dipcc_game(power_name)
                 self.player = Player(self.agent, power_name)

--- a/fairdiplomacy_external/mila_api_advisor.py
+++ b/fairdiplomacy_external/mila_api_advisor.py
@@ -520,7 +520,7 @@ class milaWrapper:
 
         dipcc_game.process() # processing the orders set and moving on to the next phase of the dipcc game
 
-    def generate_message(self, power_name: POWERS)-> MessageDict:
+    def generate_message(self, power_name: POWERS)-> Optional[MessageDict]:
         """     
         call CICERO to generate message (reference from generate_message_for_approval function - webdip_api.py)
         """

--- a/fairdiplomacy_external/mila_api_advisor.py
+++ b/fairdiplomacy_external/mila_api_advisor.py
@@ -12,6 +12,7 @@ import time
 from typing import List, Optional, Sequence
 
 from chiron_utils.bots.baseline_bot import BaselineBot, BotType
+import chiron_utils.game_utils
 from chiron_utils.utils import return_logger
 from conf.agents_pb2 import *
 from diplomacy import connect
@@ -654,13 +655,13 @@ def main() -> None:
     parser.add_argument(
         "--host",
         type=str,
-        default="localhost",
+        default=chiron_utils.game_utils.DEFAULT_HOST,
         help="host IP address (default: %(default)s)",
     )
     parser.add_argument(
         "--port",
         type=int,
-        default=8433,
+        default=chiron_utils.game_utils.DEFAULT_PORT,
         help="port to connect to the game (default: %(default)s)",
     )
     parser.add_argument(

--- a/fairdiplomacy_external/mila_api_player.py
+++ b/fairdiplomacy_external/mila_api_player.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Sequence
 from chiron_utils.bots.baseline_bot import BaselineBot, BotType
 from chiron_utils.utils import return_logger
 from conf.agents_pb2 import *
-from diplomacy import Message, connect
+from diplomacy import connect
 from diplomacy.client.network_game import NetworkGame
 from diplomacy.utils import strings
 from diplomacy.utils.export import to_saved_game_format

--- a/fairdiplomacy_external/mila_api_player.py
+++ b/fairdiplomacy_external/mila_api_player.py
@@ -11,6 +11,7 @@ import time
 from typing import List, Optional, Sequence
 
 from chiron_utils.bots.baseline_bot import BaselineBot, BotType
+import chiron_utils.game_utils
 from chiron_utils.utils import return_logger
 from conf.agents_pb2 import *
 from diplomacy import connect
@@ -559,13 +560,13 @@ def main() -> None:
     parser.add_argument(
         "--host",
         type=str,
-        default="localhost",
+        default=chiron_utils.game_utils.DEFAULT_HOST,
         help="host IP address (default: %(default)s)",
     )
     parser.add_argument(
         "--port",
         type=int,
-        default=8433,
+        default=chiron_utils.game_utils.DEFAULT_PORT,
         help="port to connect to the game (default: %(default)s)",
     )
     parser.add_argument(

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,7 +23,7 @@ botocore==1.33.13
 cachetools==5.5.0
 catalogue==2.0.10
 cfgv==3.3.1
-chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@100d391cb0ad5b355f1c9981f8adf5607e1db8d2
+chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@36a77f7e794090ace12e2a26d7f6d426a02c636b
 click==7.1.2
 cloudpathlib==0.18.1
 cloudpickle==2.2.1
@@ -45,7 +45,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
 dill==0.3.7
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@3cf9282044bf4ccb532fcece7419547e09b50fa5
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@3af242e3db6dffc1e6683389274f6f1d1ae2a728
 discordwebhook==1.0.3
 distlib==0.3.8
 docformatter==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@
 attrs==20.2.0
 black==19.10b0
 # Pinned `chiron-utils` to `main`
-chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@100d391cb0ad5b355f1c9981f8adf5607e1db8d2
+chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@36a77f7e794090ace12e2a26d7f6d426a02c636b
 colored==1.4.3
 datasets==1.18.4
 dacite==1.6.0
 daide2eng @ git+https://github.com/ALLAN-DIP/daide2eng.git@e4fa27071c52408817946598d3463f20bf064f6e
-# Pinned `diplomacy` to `clean-up-branches`
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@3cf9282044bf4ccb532fcece7419547e09b50fa5
+# Pinned `diplomacy` to `main`
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@3af242e3db6dffc1e6683389274f6f1d1ae2a728
 discordwebhook==1.0.3
 ephemeral-port-reserve==1.1.4
 fairseq==0.10.2


### PR DESCRIPTION
This PR adds an implementation for a new suggestion type that predicts the orders of opponents. I made some related improvements to the advisor, most of them being related to the suggestion code.

For the library and UI implementations, see <https://github.com/ALLAN-DIP/diplomacy/pull/34>. For client support, see <https://github.com/ALLAN-DIP/chiron-utils/pull/20>.