### PR TITLE
Use strings for `--advice_levels`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To use the advisor, run a command similar to the following:
   --use-ssl \
   --game_id test_game \
   --human_powers AUSTRIA ENGLAND \
-  --advice_levels 10 11
+  --advice_levels 'MESSAGE|MOVE|OPPONENT_MOVE' 'MOVE|OPPONENT_MOVE'
 ```
 
 To use the player, run a command similar to the following:
@@ -78,7 +78,7 @@ Use the following guidance when modifying arguments:
 - `--host` should be set to whichever domain the server is hosted at.
 - If your server is not using SSL, then drop the `--use-ssl` argument.
 - `--game_id` must match an existing game.
-- `--advice_levels` is the sum of the values for each advice type. For example, `11` means to provide advice for messages (`1`), moves (`2`), and opponent moves (`8`). For more information, see the output of `./run_cicero.sh latest advisor --help`.
+- `--advice_levels` is the joining of the values for each advice type with `|`. For example, `'MESSAGE|MOVE|OPPONENT_MOVE` means to provide advice for messages, moves, and opponent moves. The values need to be quoted in the shell so `|` is not interpreted as a shell pipe. For more information, see the output of `./run_cicero.sh latest advisor --help`.
 
 ### Downloading model files
 

--- a/fairdiplomacy_external/cicero_intent_test.py
+++ b/fairdiplomacy_external/cicero_intent_test.py
@@ -92,7 +92,6 @@ from diplomacy import Message
 from diplomacy.client.network_game import NetworkGame
 from diplomacy.utils.export import to_saved_game_format, from_saved_game_format
 from diplomacy.utils import strings
-from daide2eng.utils import gen_English, create_daide_grammar, is_daide
 
 sys.path.insert(0, '/diplomacy_cicero/fairdiplomacy/AMR/DAIDE/DiplomacyAMR/code')
 from amrtodaide import AMR

--- a/fairdiplomacy_external/mila_api_advisor.py
+++ b/fairdiplomacy_external/mila_api_advisor.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import random
 import time
-from typing import List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence
 
 from chiron_utils.bots.baseline_bot import BaselineBot, BotType
 import chiron_utils.game_utils
@@ -94,8 +94,8 @@ class milaWrapper:
         self.prev_suggest_moves = None
         self.prev_suggest_cond_moves = None
         self.power_to_advise = None
-        self.advice_level = None
-        self.weight_powers = dict()
+        self.advice_level: Optional[int] = None
+        self.weight_powers: Dict[str, float] = dict()
         self.decrement_value = 0.2
         
         agent_config = heyhi.load_config('/diplomacy_cicero/conf/common/agents/cicero.prototxt')
@@ -103,7 +103,7 @@ class milaWrapper:
 
         self.agent = PyBQRE1PAgent(agent_config.bqre1p)
         
-    async def assign_advisor(self, file_dir, power_dist, advice_levels):
+    async def assign_advisor(self, file_dir: Path, power_dist: Dict[str, float], advice_levels: List[int]) -> None:
         # random N powers
         # random level 
         self.power_to_advise = sample_p_dict(power_dist)
@@ -127,7 +127,7 @@ class milaWrapper:
         self.weight_powers = power_dist
         logger.info(f'Adjusting power distribution from {old_power_dist} to {power_dist}')
         
-    async def reload_or_assign_advisor(self, file_dir, power_dist, advice_levels):
+    async def reload_or_assign_advisor(self, file_dir: Path, power_dist: Dict[str, float], advice_levels: List[int]) -> bool:
         if os.path.exists(file_dir):
             with open(file_dir, mode="r") as file:
                 advisor_json = json.load(file)

--- a/fairdiplomacy_external/mila_api_advisor.py
+++ b/fairdiplomacy_external/mila_api_advisor.py
@@ -729,7 +729,7 @@ def main() -> None:
     advice_levels: List[str] = args.advice_levels
 
     logger.info(
-        "Arguments:"
+        "Arguments:\n"
         f"\thost: {host}\n"
         f"\tport: {port}\n"
         f"\tuse_ssl: {use_ssl}\n"

--- a/fairdiplomacy_external/mila_api_advisor.py
+++ b/fairdiplomacy_external/mila_api_advisor.py
@@ -45,15 +45,6 @@ MESSAGE_DELAY_IF_SLEEP_INF = Timestamp.from_seconds(60)
 
 DEFAULT_DEADLINE = 5
 
-ADVICE_LEVELS_MESSAGE = (
-    "Levels of advice: "
-    f"{int(SuggestionType.NONE)}: none, "
-    f"{int(SuggestionType.MESSAGE)}: message only, "
-    f"{int(SuggestionType.MOVE)}: order only, "
-    f"{int(SuggestionType.MESSAGE | SuggestionType.MOVE)}: both message and order, "
-    f"{int(SuggestionType.OPPONENT_MOVE)}: opponent moves, "
-    f"{int(SuggestionType.MESSAGE | SuggestionType.MOVE | SuggestionType.OPPONENT_MOVE)}: messages, moves, and opponent moves"
-)
 
 @dataclass
 class CiceroBot(BaselineBot, ABC):
@@ -94,7 +85,7 @@ class milaWrapper:
         self.prev_suggest_moves = None
         self.prev_suggest_cond_moves = None
         self.power_to_advise = None
-        self.advice_level: Optional[int] = None
+        self.advice_level: SuggestionType = SuggestionType.NONE
         self.weight_powers: Dict[str, float] = dict()
         self.decrement_value = 0.2
         
@@ -103,18 +94,17 @@ class milaWrapper:
 
         self.agent = PyBQRE1PAgent(agent_config.bqre1p)
         
-    async def assign_advisor(self, file_dir: Path, power_dist: Dict[str, float], advice_levels: List[int]) -> None:
+    async def assign_advisor(self, file_dir: Path, power_dist: Dict[str, float], advice_levels: List[SuggestionType]) -> None:
         # random N powers
         # random level 
         self.power_to_advise = sample_p_dict(power_dist)
-        if len(power_dist) ==1 and len(advice_levels)>1 and int(SuggestionType.NONE) not in advice_levels:
+        if len(power_dist) ==1 and len(advice_levels)>1 and SuggestionType.NONE not in advice_levels:
             logger.info(f'We are left with only one power ({list(power_dist)[0]}), '
-                        f'so let\'s add {int(SuggestionType.NONE)} as no advice to advice levels')
-            advice_levels.append(int(SuggestionType.NONE))
+                        f'so let\'s add {SuggestionType.NONE.to_parsable()} to advice levels')
+            advice_levels.append(SuggestionType.NONE)
         logger.info(f'Randomly choosing from advice levels: {advice_levels}')
         self.advice_level = random.choice(advice_levels)
         await self.send_log(f'Assigning Cicero to {self.power_to_advise} and advising at level {self.advice_level}')
-        logger.info(f"Note: {ADVICE_LEVELS_MESSAGE}")
         # write to json
         with open(file_dir, 'w') as f:
             advisor_dict = {'assign_phase': self.game.get_current_phase(), 'power_to_advise':self.power_to_advise, 'advice_level':self.advice_level}
@@ -127,10 +117,12 @@ class milaWrapper:
         self.weight_powers = power_dist
         logger.info(f'Adjusting power distribution from {old_power_dist} to {power_dist}')
         
-    async def reload_or_assign_advisor(self, file_dir: Path, power_dist: Dict[str, float], advice_levels: List[int]) -> bool:
+    async def reload_or_assign_advisor(self, file_dir: Path, power_dist: Dict[str, float], advice_levels: List[SuggestionType]) -> bool:
         if os.path.exists(file_dir):
             with open(file_dir, mode="r") as file:
                 advisor_json = json.load(file)
+            # Convert fron `int` to enum
+            advisor_json["advice_level"] = SuggestionType(advisor_json["advice_level"])
                 
             game_phase = self.game.get_current_phase()
             phase_file = advisor_json['assign_phase']
@@ -139,7 +131,6 @@ class milaWrapper:
                 self.power_to_advise = advisor_json['power_to_advise']
                 self.advice_level = advisor_json['advice_level']
                 logger.info(f'Re-assigning Cicero to {self.power_to_advise} and advising {self.advice_level}')
-                logger.info(f"Note: {ADVICE_LEVELS_MESSAGE}")
                 return True
 
         await self.assign_advisor(file_dir, power_dist, advice_levels)
@@ -169,9 +160,8 @@ class milaWrapper:
         game_id: str,
         gamedir: Path ,
         human_powers: List[str],
-        advice_levels_strs: List[str],
+        advice_levels: List[SuggestionType],
     ) -> None:
-        advice_levels = [int(l) for l in advice_levels_strs]
         power_name = None
 
         connection = await connect(hostname, port, use_ssl)
@@ -677,7 +667,10 @@ class milaWrapper:
 
             
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
     parser.add_argument(
         "--host",
         type=str,
@@ -710,7 +703,19 @@ def main() -> None:
     parser.add_argument(
         "--advice_levels",
         nargs="+",
-        help=ADVICE_LEVELS_MESSAGE,
+        default=CiceroAdvisor.default_suggestion_type.to_parsable(),
+        type=SuggestionType.parse,
+        help=(
+            "Levels of advice:\n"
+            f"- {SuggestionType.NONE.to_parsable()!r}\n"
+            f"- {SuggestionType.MESSAGE.to_parsable()!r}\n"
+            f"- {SuggestionType.MOVE.to_parsable()!r}\n"
+            f"- {SuggestionType.OPPONENT_MOVE.to_parsable()!r}\n"
+            "Levels can be combined, such as using "
+            f"{(SuggestionType.MESSAGE | SuggestionType.MOVE).to_parsable()!r} "
+            "for both message and move advice.\n"
+            "(default: %(default)s)"
+        )
     )
     parser.add_argument(
         "--outdir",
@@ -726,7 +731,11 @@ def main() -> None:
     game_id: str = args.game_id
     outdir: Path = args.outdir
     human_powers: List[str] = args.human_powers
-    advice_levels: List[str] = args.advice_levels
+    # Ensure that argument is always a `list`
+    if isinstance(args.advice_levels, SuggestionType):
+        advice_levels: List[SuggestionType] = [args.advice_levels]
+    else:
+        advice_levels = args.advice_levels
 
     logger.info(
         "Arguments:\n"
@@ -736,7 +745,7 @@ def main() -> None:
         f"\tgame_id: {game_id}\n"
         f"\toutdir: {outdir}\n"
         f"\thuman_powers: {human_powers}\n"
-        f"\tadvice_levels: {advice_levels}\n"
+        f"\tadvice_levels: {[level.to_parsable() for level in advice_levels]}\n"
     )
 
     mila = milaWrapper()
@@ -752,7 +761,7 @@ def main() -> None:
                     game_id=game_id,
                     gamedir=outdir,
                     human_powers=human_powers,
-                    advice_levels_strs=advice_levels,
+                    advice_levels=advice_levels,
                 )
             )
         except Exception as e:

--- a/fairdiplomacy_external/mila_api_advisor.py
+++ b/fairdiplomacy_external/mila_api_advisor.py
@@ -220,8 +220,6 @@ class milaWrapper:
             if not is_reload_advisor or power_name is None:
                 power_name = self.get_curr_power_to_advise()
                 self.chiron_type = self.get_curr_advice_level()
-                # Only one instance of `ChironAdvisor` exists at a time,
-                # so this is actually safe
                 self.chiron_agent.suggestion_type = self.chiron_type
                 self.chiron_agent.power_name = power_name
                 self.dipcc_game = self.start_dipcc_game(power_name)

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,7 +23,7 @@ botocore==1.33.13
 cachetools==5.5.0
 catalogue==2.0.10
 cfgv==3.3.1
-chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@fa73ef98c1ac04f8f2b07c59f828424115fb4082
+chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@f9f206953ff3109dc0b03310dc86e7b5c0962592
 click==7.1.2
 cloudpathlib==0.18.1
 cloudpickle==2.2.1
@@ -44,7 +44,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
 dill==0.3.7
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@f600344158c85fb933b6c1d0fff61e80bd529648
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@2270f351b0bb1423415644487f8abf7bddd06754
 discordwebhook==1.0.3
 distlib==0.3.8
 docformatter==1.4

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -36,7 +36,6 @@ cycler==0.11.0
 cymem==2.0.8
 Cython==3.0.11
 dacite==1.6.0
-daide2eng @ git+https://github.com/ALLAN-DIP/daide2eng.git@e4fa27071c52408817946598d3463f20bf064f6e
 daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@f84f7279fb4a31083ad8e4b5fcf6d1ed290bae0e
 dataclasses==0.6
 datasets==1.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 attrs==20.2.0
 black==19.10b0
 # Pinned `chiron-utils` to `main`
-chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@fa73ef98c1ac04f8f2b07c59f828424115fb4082
+chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@f9f206953ff3109dc0b03310dc86e7b5c0962592
 colored==1.4.3
 datasets==1.18.4
 dacite==1.6.0
 # Pinned `diplomacy` to `main`
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@f600344158c85fb933b6c1d0fff61e80bd529648
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@2270f351b0bb1423415644487f8abf7bddd06754
 discordwebhook==1.0.3
 ephemeral-port-reserve==1.1.4
 fairseq==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@fa73ef98c1ac04f
 colored==1.4.3
 datasets==1.18.4
 dacite==1.6.0
-daide2eng @ git+https://github.com/ALLAN-DIP/daide2eng.git@e4fa27071c52408817946598d3463f20bf064f6e
 # Pinned `diplomacy` to `main`
 diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@f600344158c85fb933b6c1d0fff61e80bd529648
 discordwebhook==1.0.3


### PR DESCRIPTION
This PR replaces the `int`s being used for `--advice_levels` with `str` as arguments and with `SuggestionType` values internally. This makes the UI much nicer to work with!

I also included some minor changes I had locally, most of which are directly related to advice level handling.