### PR TITLE
Add support for order probability advice

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,7 +23,7 @@ botocore==1.33.13
 cachetools==5.5.0
 catalogue==2.0.10
 cfgv==3.3.1
-chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@f9f206953ff3109dc0b03310dc86e7b5c0962592
+chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@7afb0f9bffc88123428fd69f49befd03bb752457
 click==7.1.2
 cloudpathlib==0.18.1
 cloudpickle==2.2.1
@@ -44,7 +44,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
 dill==0.3.7
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@2270f351b0bb1423415644487f8abf7bddd06754
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@aa6055fe9b933bd393a0339568e102534bb2009c
 discordwebhook==1.0.3
 distlib==0.3.8
 docformatter==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 attrs==20.2.0
 black==19.10b0
 # Pinned `chiron-utils` to `main`
-chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@f9f206953ff3109dc0b03310dc86e7b5c0962592
+chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@7afb0f9bffc88123428fd69f49befd03bb752457
 colored==1.4.3
 datasets==1.18.4
 dacite==1.6.0
 # Pinned `diplomacy` to `main`
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@2270f351b0bb1423415644487f8abf7bddd06754
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@aa6055fe9b933bd393a0339568e102534bb2009c
 discordwebhook==1.0.3
 ephemeral-port-reserve==1.1.4
 fairseq==0.10.2


### PR DESCRIPTION
This PR adds support for order probability advice using the new text and visual suggestion types in the UI.

This implementation took me longer than expected because I hadn't realized that Cicero calculated probabilities for _sets_ of orders, not individual orders. In the current code, an order's probability is the probability of the most likely set of orders that the given order is included in. However, I am considering making an order's probability the sum of the probabilities of all sets of orders that the given order is included in. I am also considering looking into increasing the number of sets of orders being returned to allow more orders to be included. Any feedback on my approach would be appreciated!

I'm not sure who should review this, but I added everyone that seemed relevant. If you don't think you should review this, feel free to remove yourself from the reviewer list.

Thanks to @sadrasabouri for his initial implementation of getting order probabilities from Cicero and @wwongkamjan for her help related to that.