### PR TITLE
Presubmit update

### DIFF
--- a/fairdiplomacy_external/mila_api_player.py
+++ b/fairdiplomacy_external/mila_api_player.py
@@ -599,7 +599,7 @@ def main() -> None:
     parser.add_argument(
         "--first_submit_time_deadline",
         type=int,
-        default=120,
+        default=7200,
         help="Deadline for the first submit time in seconds. (default: %(default)s)",
     )
     args = parser.parse_args()


### PR DESCRIPTION
I updated args to control presubmit seconds that cicero player should submit **its first order**. For the sake of demo, we want cicero to submit at the beginning of the turn (ddl can be 10 minutes, 2 hours) so I set default as 7200 (seconds) to make sure that it's default align with all those ddl. 