### PR TITLE
Merge changes from upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ dipcc/Testing/
 /src/
 dipcc/detect_cuda_version.cc
 node_modules/
+
+# Created by `bin/download_model_files.sh`
+/models_encrypted/


### PR DESCRIPTION
The upstream repository (<https://github.com/facebookresearch/diplomacy_cicero>) had some changes before it was archived in April 2025. This PR merges these changes, the most important of which is updated instructions for downloading the model files.