### PR TITLE
Update `chiron-utils` and `diplomacy`

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,7 +23,7 @@ botocore==1.33.13
 cachetools==5.5.0
 catalogue==2.0.10
 cfgv==3.3.1
-chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@7d1e4eb53473fb5ef30c2f524d6aaaeff89860f8
+chiron-utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@9f6303f104d3949b91e4a381698eb5d3733be1a8
 click==7.1.2
 cloudpathlib==0.18.1
 cloudpickle==2.2.1
@@ -44,7 +44,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
 dill==0.3.7
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@9e7bf501b3b58bfb348dcc21671337cec40ea065
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@33b28982ba2b294e0508a263662ec92f7cff89b9
 discordwebhook==1.0.3
 distlib==0.3.8
 docformatter==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 attrs==20.2.0
 black==19.10b0
 # Pinned `chiron-utils` to `main`
-chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@7d1e4eb53473fb5ef30c2f524d6aaaeff89860f8
+chiron_utils @ git+https://github.com/ALLAN-DIP/chiron-utils.git@9f6303f104d3949b91e4a381698eb5d3733be1a8
 colored==1.4.3
 datasets==1.18.4
 dacite==1.6.0
 # Pinned `diplomacy` to `main`
-diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@9e7bf501b3b58bfb348dcc21671337cec40ea065
+diplomacy @ git+https://github.com/ALLAN-DIP/diplomacy.git@33b28982ba2b294e0508a263662ec92f7cff89b9
 discordwebhook==1.0.3
 ephemeral-port-reserve==1.1.4
 fairseq==0.10.2


### PR DESCRIPTION
This PR updates these dependencies to match the versions on `main` in the other repositories.

I was able to build Cicero and run the advisor without any issue.